### PR TITLE
skip endpoint discovery

### DIFF
--- a/esi/lease/v1/_proxy.py
+++ b/esi/lease/v1/_proxy.py
@@ -27,6 +27,7 @@ class Proxy(proxy.Proxy):
         "node": _node.Node,
         "event": _event.Event
     }
+    skip_discovery = True
 
     def _get_with_fields(self, resource_type, value, fields=None):
         """Fetch an ESI-LEAP resource.

--- a/esi/tests/fakes.py
+++ b/esi/tests/fakes.py
@@ -76,5 +76,5 @@ def make_fake_event(id, event_type, last_event_time):
 
 
 def get_lease_endpoint():
-    url = "https://lease.example.com/v1"
+    url = "https://lease.example.com"
     return ks_discover.EndpointData(catalog_url=url, api_version=(1, 0))


### PR DESCRIPTION
This PR adds the logic to skip esi-leap endpoint discovery, so that esisdk won't make call to `http://129.10.5.142:7777` at first to obtain the endpoint url.