### PR TITLE
Remove erroneous .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
We have configured git to ignore directories named `lib`, but all of our
code lives in `esi/lib`, resulting in errors along the lines of:

    The following paths are ignored by one of your .gitignore files:
    esi/tests/unit/lib
    hint: Use -f if you really want to add them.
    hint: Disable this message with "git config advice.addIgnoredFile false"

This commit removes lib from our .gitignore file.
