### PR TITLE
Clean up dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,5 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-pbr!=2.1.0,>=2.0.0 # Apache-2.0
-PyYAML>=3.13 # MIT
-appdirs>=1.3.0 # MIT License
-requestsexceptions>=1.2.0 # Apache-2.0
-jsonpatch!=1.20,>=1.16 # BSD
-os-service-types>=1.7.0 # Apache-2.0
 keystoneauth1>=3.18.0 # Apache-2.0
 openstacksdk # Apache-2.0
-decorator>=4.4.1 # BSD
-jmespath>=0.9.0 # MIT
-iso8601>=0.1.11 # MIT
-netifaces>=0.10.4 # MIT
-
-dogpile.cache>=0.6.5 # BSD
-cryptography>=2.7 # BSD/Apache-2.0
-
-importlib-metadata<5.0.0; python_version<'3.8' # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,16 +5,7 @@ hacking>=3.1.0,<4.0.0 # Apache-2.0
 
 mock>=3.0.0 # BSD
 coverage!=4.4,>=4.0 # Apache-2.0
-ddt>=1.0.1 # MIT
-fixtures>=3.0.0 # Apache-2.0/BSD
-jsonschema>=3.2.0 # MIT
-prometheus-client>=0.4.2 # Apache-2.0
 oslo.config>=6.1.0 # Apache-2.0
 oslotest>=3.2.0 # Apache-2.0
-openstacksdk # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
-statsd>=3.3.0
 stestr>=1.0.0 # Apache-2.0
-testscenarios>=0.4 # Apache-2.0/BSD
-testtools>=2.2.0 # MIT
-importlib-metadata<5.0.0; python_version<'3.8' # Apache-2.0


### PR DESCRIPTION
Remove all the requirements from `requirements.txt` and `test-requirements.txt` that are not directly required by esisdk.

Closes: #22
