### PR TITLE
Update test OS to Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   run-tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
Ubuntu 20.04 was deprecated on 2025-04-15; this updates the test environment to use the supported Ubuntu 24.04 image.